### PR TITLE
Fix description of count method in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ RNGeofence.clear();
 
 ### count()
 
-Clears all geofences. Available only on iOS. The promise resolves with a number. 
+Counts all current geofences. Available only on iOS. The promise resolves with a number. 
 
 Android returns -1
 


### PR DESCRIPTION
Fixes description of the `count()` method, which appears to have a copy/paste issue from the `clear()` method.